### PR TITLE
Lowercase extension of item before comparing with accepted imageTypes

### DIFF
--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -41,7 +41,8 @@
     max = items.length;
 
     for (const item of items) {
-      if (imageTypes.includes('.' + item.pathname.split('.').at(-1) || '')) {
+      const itemFileExtension = ('.' + item.pathname.split('.').at(-1)).toLowerCase();
+      if (imageTypes.includes(itemFileExtension || '')) {
         const image = await fetch(url + item.pathname);
         const blob = await image.blob();
         const file = new File([blob], item.pathname.substring(1));


### PR DESCRIPTION
NotSusStupid reported, [on Discord](https://discord.com/channels/617136488840429598/1104805874301669537/1201575059832193136), that “the catalog can't import images with an upper case extension”. 

`const imageTypes` only includes lowercase extensions in its list of accepted image types, which excludes equally valid image extensions like `.PNG` and `.WEBP`, so I simply lowercased the file extension before checking if it is included in `imageTypes`.