### PR TITLE
Update underscore prefix for image filenames

### DIFF
--- a/src/lib/anki-connect/index.ts
+++ b/src/lib/anki-connect/index.ts
@@ -102,7 +102,7 @@ export async function updateLastCard(imageData: string | null | undefined, sente
         id,
         fields,
         picture: {
-          filename: `_${id}.webp`,
+          filename: `${id}.webp`,
           data: imageData.split(';base64,')[1],
           fields: [pictureField],
         },

--- a/src/lib/anki-connect/index.ts
+++ b/src/lib/anki-connect/index.ts
@@ -102,7 +102,7 @@ export async function updateLastCard(imageData: string | null | undefined, sente
         id,
         fields,
         picture: {
-          filename: `${id}.webp`,
+          filename: `mokuro_${id}.webp`,
           data: imageData.split(';base64,')[1],
           fields: [pictureField],
         },


### PR DESCRIPTION
Fix for this issue: https://github.com/ZXY101/mokuro-reader/issues/39

Media files that are prefixed by an underscore do not get checked by Anki's "Check Media" functionality. That means if an Anki note that has been created or updated via this reader gets deleted later on, Anki users must manually find + delete the image files that were referenced by the note.

This PR changes the underscore prefix on the image filename to allow for "Check Media" to work for detecting unused media files. The prefix added is "mokuro_*" to solve the Anki issue + reduce collision chance with random files from other sources, and aligns with the following commit on a fork for the same purpose:

https://github.com/KojoZero/mokuro-reader/commit/6d550cbe8ac93c7193bfe3ee84ee0e34a1b57bf7