### PR TITLE
Enhance image processing settings in AnkiConnect

### DIFF
--- a/src/lib/anki-connect/cropper.ts
+++ b/src/lib/anki-connect/cropper.ts
@@ -1,6 +1,7 @@
 import { showSnackbar } from '$lib/util';
 import { writable } from 'svelte/store';
 import { blobToBase64, imageResize } from '.';
+import { Settings } from '$lib/settings';
 
 type CropperModal = {
   open: boolean;
@@ -34,7 +35,7 @@ function getRadianAngle(degreeValue: number) {
 
 export type Pixels = { width: number; height: number; x: number; y: number }
 
-export async function getCroppedImg(imageSrc: string, pixelCrop: Pixels, settings: any, rotation = 0 ) {
+export async function getCroppedImg(imageSrc: string, pixelCrop: Pixels, settings: Settings, rotation = 0 ) {
   const image = await createImage(imageSrc);
   const canvas = new OffscreenCanvas(image.width, image.height);
   const ctx = canvas.getContext('2d');

--- a/src/lib/anki-connect/cropper.ts
+++ b/src/lib/anki-connect/cropper.ts
@@ -1,6 +1,6 @@
 import { showSnackbar } from '$lib/util';
 import { writable } from 'svelte/store';
-import { blobToBase64 } from '.';
+import { blobToBase64, imageResize } from '.';
 
 type CropperModal = {
   open: boolean;
@@ -34,7 +34,7 @@ function getRadianAngle(degreeValue: number) {
 
 export type Pixels = { width: number; height: number; x: number; y: number }
 
-export async function getCroppedImg(imageSrc: string, pixelCrop: Pixels, rotation = 0) {
+export async function getCroppedImg(imageSrc: string, pixelCrop: Pixels, settings: any, rotation = 0 ) {
   const image = await createImage(imageSrc);
   const canvas = new OffscreenCanvas(image.width, image.height);
   const ctx = canvas.getContext('2d');
@@ -71,8 +71,9 @@ export async function getCroppedImg(imageSrc: string, pixelCrop: Pixels, rotatio
     Math.round(0 - safeArea / 2 + image.width * 0.5 - pixelCrop.x),
     Math.round(0 - safeArea / 2 + image.height * 0.5 - pixelCrop.y)
   );
-
-  const blob = await canvas.convertToBlob({ type: 'image/webp' });
+  
+  await imageResize(canvas, ctx, settings.ankiConnectSettings.widthField, settings.ankiConnectSettings.heightField);
+  const blob = await canvas.convertToBlob({ type: 'image/webp', quality: settings.ankiConnectSettings.qualityField });
 
   return await blobToBase64(blob)
 }

--- a/src/lib/anki-connect/index.ts
+++ b/src/lib/anki-connect/index.ts
@@ -1,4 +1,4 @@
-import { settings } from "$lib/settings";
+import { Settings, settings } from "$lib/settings";
 import { showSnackbar } from "$lib/util"
 import { get } from "svelte/store";
 
@@ -50,7 +50,7 @@ export async function blobToBase64(blob: Blob) {
   });
 }
 
-export async function imageToWebp(source: File, settings: any) {
+export async function imageToWebp(source: File, settings: Settings) {
   const image = await createImageBitmap(source);
   const canvas = new OffscreenCanvas(image.width, image.height);
   const context = canvas.getContext("2d");

--- a/src/lib/components/Reader/Cropper.svelte
+++ b/src/lib/components/Reader/Cropper.svelte
@@ -37,7 +37,7 @@
   async function onCrop() {
     if ($cropperStore?.image && pixels) {
       loading = true;
-      const imageData = await getCroppedImg($cropperStore.image, pixels);
+      const imageData = await getCroppedImg($cropperStore.image, pixels, $settings);
       updateLastCard(imageData, $cropperStore.sentence);
       close();
     }

--- a/src/lib/components/Reader/QuickActions.svelte
+++ b/src/lib/components/Reader/QuickActions.svelte
@@ -40,7 +40,7 @@
         showCropper(URL.createObjectURL(src));
       } else {
         promptConfirmation('Add image to last created anki card?', async () => {
-          const imageData = await imageToWebp(src);
+          const imageData = await imageToWebp(src, $settings);
           updateLastCard(imageData);
         });
       }

--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -54,7 +54,7 @@
         showCropper(URL.createObjectURL(src), sentence);
       } else {
         promptConfirmation('Add image to last created anki card?', async () => {
-          const imageData = await imageToWebp(src);
+          const imageData = await imageToWebp(src, $settings);
           updateLastCard(imageData, sentence);
         });
       }

--- a/src/lib/components/Settings/AnkiConnectSettings.svelte
+++ b/src/lib/components/Settings/AnkiConnectSettings.svelte
@@ -13,6 +13,10 @@
   let pictureField = $settings.ankiConnectSettings.pictureField;
   let sentenceField = $settings.ankiConnectSettings.sentenceField;
 
+  let heightField = $settings.ankiConnectSettings.heightField;
+  let widthField = $settings.ankiConnectSettings.widthField;
+  let qualityField = $settings.ankiConnectSettings.qualityField;
+
   let triggerMethod = $settings.ankiConnectSettings.triggerMethod;
 
   const triggerOptions = [
@@ -89,6 +93,38 @@
           bind:value={triggerMethod}
         />
       </Label>
+    </div>
+    <hr>
+    <h4>Quality Settings</h4>
+    <Helper>Allows you to customize the file size stored on your devices</Helper>
+    <div>
+      <Label>Max Height (0 = Ignore; 200 Recommended):</Label>
+      <Input
+        {disabled}
+        type="number"
+        bind:value={heightField}
+        on:change={() => {updateAnkiSetting('heightField', heightField); if (heightField < 0) heightField = 0;}}
+        min={0}
+      />
+    </div>
+    <div>
+      <Label>Max Width (0 = Ignore; 200 Recommended):</Label>
+      <Input
+        {disabled}
+        type="number"
+        bind:value={widthField}
+        on:change={() => {updateAnkiSetting('widthField', widthField); if (widthField < 0) widthField = 0;}}
+        min={0}
+      />
+    </div>
+    <div>
+      <Label>Quality (Between 0 and 1; 0.5 Recommended):</Label>
+      <Input
+        {disabled}
+        type="number"
+        bind:value={qualityField}
+        on:change={() => updateAnkiSetting('qualityField', qualityField)}
+      />
     </div>
   </div>
 </AccordionItem>

--- a/src/lib/components/Settings/AnkiConnectSettings.svelte
+++ b/src/lib/components/Settings/AnkiConnectSettings.svelte
@@ -124,6 +124,9 @@
         type="number"
         bind:value={qualityField}
         on:change={() => updateAnkiSetting('qualityField', qualityField)}
+        min={0}
+        max={1} 
+        step="0.1"
       />
     </div>
   </div>

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -28,6 +28,9 @@ export type AnkiConnectSettings = {
   enabled: boolean;
   pictureField: string;
   sentenceField: string;
+  heightField: number;
+  widthField: number;
+  qualityField: number;
   cropImage: boolean;
   overwriteImage: boolean;
   grabSentence: boolean;
@@ -98,6 +101,9 @@ const defaultSettings: Settings = {
     overwriteImage: true,
     pictureField: 'Picture',
     sentenceField: 'Sentence',
+    heightField: 200,
+    widthField: 200,
+    qualityField: 0.5,
     triggerMethod: 'both'
   }
 };

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -101,9 +101,9 @@ const defaultSettings: Settings = {
     overwriteImage: true,
     pictureField: 'Picture',
     sentenceField: 'Sentence',
-    heightField: 200,
-    widthField: 200,
-    qualityField: 0.5,
+    heightField: 0,
+    widthField: 0,
+    qualityField: 1,
     triggerMethod: 'both'
   }
 };


### PR DESCRIPTION
- Added height, width, and quality fields to AnkiConnect settings.
- Updated imageToWebp and getCroppedImg functions to accept settings for resizing and quality.
- Integrated settings into Cropper and QuickActions components for improved image handling.

Reason Note:

This enhancement gives the users options to resize and lower the quality of the images put into Anki when mining cards. With no resize and quality settings, 1,000 words mined (manga image size of 1200x1800 pixels) takes up 1gb of space.

I've created a feature that allows you to resize and lower the quality of the images put into anki. With the recommended settings of max width/height of 200px and 50% quality (0.5) each file is ~5kb. It would take 200,000 words mined to take up 1 GB of space.

This feature can be disabled by settings the max quality to 1 and max width and height to 0. The user is in full control of these changes.

![image](https://github.com/user-attachments/assets/c6582688-256f-454d-81c6-66c388c0eeb6)
![image](https://github.com/user-attachments/assets/c3629e2b-1da3-4ba7-bcbf-f1f0d5f7ab84)

