### PR TITLE
set manifest display to fullscreen so PWAs on android can start fullscreen

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -53,7 +53,7 @@
   ],
   "start_url": "/",
   "background_color": "#030712",
-  "display": "standalone",
+  "display": "fullscreen",
   "scope": "/",
   "theme_color": "#030712",
   "description": "Reader for Mokuro processed manga"


### PR DESCRIPTION
this works well for ttu-reader, we'll see what happens here.